### PR TITLE
Improve ocamlmig --version

### DIFF
--- a/lib/ocamlmig.ml
+++ b/lib/ocamlmig.ml
@@ -1041,7 +1041,7 @@ let main () =
   let hidden ((name, _) as cmd) =
     if Array.length Sys.argv >= 2 && Sys.argv.(1) =: name then Some cmd else None
   in
-  Command_unix.run
+  Command_unix.run ~version:"%%VERSION%%"
     (Command.group ~summary:"A tool for rewriting ocaml code"
        (List.concat
           [ [ migrate; transform ]


### PR DESCRIPTION
By default, core commands do not implement the `--version` flag. This PR makes use of the `dune subst` command run during `opam install` so `ocamlmig --version` shows something meaningful when installed from opam.

By the way, I didn't know that, but it seems like this does something useful too when pinning the package from a local repo. As I did this with the tip of this PR, and got:

```sh
$ ocamlmig --version
837eb38
```